### PR TITLE
Fixed deprecated calls

### DIFF
--- a/index.less
+++ b/index.less
@@ -33,12 +33,7 @@
 
 /* Editor Styling *********************************************************************************/
 
-.editor-colors {
-    background-color: @background-color;
-    color: @text-color;
-}
-
-.editor {
+.atom-text-editor {
     background-color: @background-color;
     color: @text-color;
 


### PR DESCRIPTION
.editor and .editor-colors are deprecated identifiers. 
I changed those to the now relevenat .atom-text-editor
Then I removed the first occurence as the same info was in the second occurence.
